### PR TITLE
Auto normalizing numerical-type URL variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	regexpNumericalURLVars = regexp.MustCompile(`/[0-9]+[/\s]`)
+	regexpNumericalURLVars = regexp.MustCompile(`[/=][0-9]+[/\s&?]`)
 )
 
 type tomlConfig struct {
@@ -448,18 +448,7 @@ func main() {
 						}
 					}
 					if config.NormalizeNumericalURLVars {
-						indices := regexpNumericalURLVars.FindAllStringIndex(url, -1)
-						if len(indices) != 0 {
-							pos := 0
-							newURL := ""
-							for i := range indices {
-								start, end := indices[i][0], indices[i][1]
-								newURL += url[pos:start+1] + ":num"
-								pos = end - 1
-							}
-							newURL += url[pos:]
-							url = newURL
-						}
+						url = normalizeNumericalURLVars(url)
 					}
 					time, err := strconv.ParseFloat(s[config.DurationIndex], 10)
 					if err == nil {
@@ -541,4 +530,20 @@ func main() {
 		log.Fatal("No parsed requests found. Please confirm log_format.")
 	}
 	showTop(allTimes)
+}
+
+func normalizeNumericalURLVars(url string) string {
+	indices := regexpNumericalURLVars.FindAllStringIndex(url, -1)
+	if len(indices) == 0 {
+		return url
+	}
+	pos := 0
+	newURL := ""
+	for i := range indices {
+		start, end := indices[i][0], indices[i][1]
+		newURL += url[pos:start+1] + "<num>"
+		pos = end - 1
+	}
+	newURL += url[pos:]
+	return newURL
 }

--- a/main.go
+++ b/main.go
@@ -17,20 +17,26 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+var (
+	regexpNumberURLVars              = regexp.MustCompile(`/[0-9]+/`)
+	regexpNumberURLVarsEndsWithSpace = regexp.MustCompile(`/[0-9]+\s`)
+)
+
 type tomlConfig struct {
-	RankingCount   int  `toml:"ranking_count"`
-	SlowCount      int  `toml:"slow_count"`
-	ShowStdDev     bool `toml:"show_stddev"`
-	ShowStatusCode bool `toml:"show_status_code"`
-	Percentiles    []float64
-	Scale          int
-	EffectiveDigit int    `toml:"effective_digit"`
-	LogFormat      string `toml:"log_format"`
-	RequestIndex   int    `toml:"request_index"`
-	StatusIndex    int    `toml:"status_index"`
-	DurationIndex  int    `toml:"duration_index"`
-	Bundle         []bundleConfig
-	Bundles        map[string]bundleConfig // for backward compatibility
+	RankingCount    int  `toml:"ranking_count"`
+	NormalizeNumber bool `toml:"normalize_number"`
+	SlowCount       int  `toml:"slow_count"`
+	ShowStdDev      bool `toml:"show_stddev"`
+	ShowStatusCode  bool `toml:"show_status_code"`
+	Percentiles     []float64
+	Scale           int
+	EffectiveDigit  int    `toml:"effective_digit"`
+	LogFormat       string `toml:"log_format"`
+	RequestIndex    int    `toml:"request_index"`
+	StatusIndex     int    `toml:"status_index"`
+	DurationIndex   int    `toml:"duration_index"`
+	Bundle          []bundleConfig
+	Bundles         map[string]bundleConfig // for backward compatibility
 
 	ShowBytes  bool `toml:"show_bytes"`
 	BytesIndex int  `toml:"bytes_index"`
@@ -441,6 +447,10 @@ func main() {
 							url = name
 							break
 						}
+					}
+					if config.NormalizeNumber {
+						url = regexpNumberURLVars.ReplaceAllString(url, "/<num>/")
+						url = regexpNumberURLVarsEndsWithSpace.ReplaceAllString(url, "/<num> ")
 					}
 					time, err := strconv.ParseFloat(s[config.DurationIndex], 10)
 					if err == nil {


### PR DESCRIPTION
Hi! Thank you for creating this awesome cli.

This PR adds option to auto-normalize numerical-type url variable. The application of ISUCON tends to adopt an auto-increment integer type as a primary key. So most of `bundles` of kataribe I added for ISUCON is just normalizing the numerical-typed url variables. In such a situation, I think this option is quite useful.

**Before (without no custom bundles):**

```
Top 20 Sort By Total
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  120  48.435  0.403625  0.848648   0.000   0.086   2.351   2.840   3.001   3.004  105    0   15    0        5003          0         41         46  POST /api/events/11/actions/reserve HTTP/1.1
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
  118  14.794  0.125373  0.058796   0.037   0.118   0.209   0.233   0.280   0.282  118    0    0    0     6251219      52971      52976      52998  GET /api/events/10 HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
    6   4.058  0.676333  0.448627   0.398   0.488   1.663   1.663   1.663   1.663    6    0    0    0     2991463         67     498577     997608  GET /admin/api/reports/events/10/sales HTTP/1.1
    9   2.869  0.318778  0.538477   0.004   0.033   1.738   1.738   1.738   1.738    8    0    1    0        3056          0        339        989  GET /admin/api/reports/events/11/sales HTTP/1.1
    1   2.810  2.810000  0.000000   2.810   2.810   2.810   2.810   2.810   2.810    1    0    0    0           0          0          0          0  DELETE /api/events/11/sheets/C/194/reservation HTTP/1.1
    1   2.796  2.796000  0.000000   2.796   2.796   2.796   2.796   2.796   2.796    1    0    0    0        2573       2573       2573       2573  GET /api/users/2272 HTTP/1.1
    1   2.756  2.756000  0.000000   2.756   2.756   2.756   2.756   2.756   2.756    1    0    0    0        2443       2443       2443       2443  GET /api/users/2226 HTTP/1.1
    1   2.681  2.681000  0.000000   2.681   2.681   2.681   2.681   2.681   2.681    1    0    0    0        2510       2510       2510       2510  GET /api/users/3085 HTTP/1.1
    1   2.576  2.576000  0.000000   2.576   2.576   2.576   2.576   2.576   2.576    1    0    0    0        2479       2479       2479       2479  GET /api/users/70 HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/10/sheets/B/58/reservation HTTP/1.1
    1   2.515  2.515000  0.000000   2.515   2.515   2.515   2.515   2.515   2.515    1    0    0    0        2404       2404       2404       2404  GET /api/users/53 HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
    4   2.429  0.607250  0.883425   0.028   0.190   2.134   2.134   2.134   2.134    4    0    0    0         268         67         67         67  GET /admin/api/reports/events/20/sales HTTP/1.1
    6   2.411  0.401833  0.811961   0.010   0.048   2.217   2.217   2.217   2.217    6    0    0    0         402         67         67         67  GET /admin/api/reports/events/19/sales HTTP/1.1
    1   2.396  2.396000  0.000000   2.396   2.396   2.396   2.396   2.396   2.396    1    0    0    0        2494       2494       2494       2494  GET /api/users/836 HTTP/1.1
    1   2.345  2.345000  0.000000   2.345   2.345   2.345   2.345   2.345   2.345    1    0    0    0        2478       2478       2478       2478  GET /api/users/4740 HTTP/1.1
```

<details>

<summary>full output</summary>

```
$ less ./access.log | ./kataribe 
Top 20 Sort By Count
Count   Total      Mean    Stddev    Min  P50.0  P90.0  P95.0  P99.0    Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  291  10.790  0.037079  0.044029  0.001  0.021  0.092  0.138  0.188  0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
  143   0.008  0.000056  0.000308  0.000  0.000  0.000  0.000  0.001  0.003  143    0    0    0    10107526      70682      70682      70682  GET /js/bootstrap.bundle.min.js HTTP/1.1
  143   0.018  0.000126  0.000938  0.000  0.000  0.000  0.001  0.001  0.011  143    0    0    0     9998131      69917      69917      69917  GET /js/jquery-3.3.1.slim.min.js HTTP/1.1
  143   0.033  0.000231  0.001408  0.000  0.000  0.000  0.000  0.010  0.011  143    0    0    0    12362636      86452      86452      86452  GET /js/vue.min.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0     1208922       8454       8454       8454  GET /js/admin.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0     1049191       7337       7337       7337  GET /js/fetch.min.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0      156156       1092       1092       1092  GET /favicon.ico HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0      101101        707        707        707  GET /css/layout.css HTTP/1.1
  143   0.129  0.000902  0.002859  0.000  0.000  0.001  0.007  0.013  0.021  143    0    0    0    20152990     140930     140930     140930  GET /css/bootstrap.min.css HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0       97812        684        684        684  GET /css/admin.css HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0     1459172      10204      10204      10204  GET /js/app.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0      296582       2074       2074       2074  GET /js/bootstrap-waitingfor.min.js HTTP/1.1
  120  48.435  0.403625  0.848648  0.000  0.086  2.351  2.840  3.001  3.004  105    0   15    0        5003          0         41         46  POST /api/events/11/actions/reserve HTTP/1.1
  118  14.794  0.125373  0.058796  0.037  0.118  0.209  0.233  0.280  0.282  118    0    0    0     6251219      52971      52976      52998  GET /api/events/10 HTTP/1.1
  118  28.418  0.240831  0.118731  0.033  0.245  0.411  0.438  0.525  0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
   48   1.525  0.031771  0.037419  0.000  0.015  0.085  0.123  0.147  0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
   32   1.852  0.057875  0.055826  0.002  0.043  0.109  0.168  0.258  0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
   31  16.499  0.532226  0.869186  0.001  0.011  2.022  2.184  2.243  2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
    9   2.869  0.318778  0.538477  0.004  0.033  1.738  1.738  1.738  1.738    8    0    1    0        3056          0        339        989  GET /admin/api/reports/events/11/sales HTTP/1.1
    8   0.146  0.018250  0.025922  0.000  0.005  0.070  0.070  0.070  0.070    4    0    4    0       47961         32       5995      11963  POST /admin/api/events HTTP/1.1

Top 20 Sort By Total
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  120  48.435  0.403625  0.848648   0.000   0.086   2.351   2.840   3.001   3.004  105    0   15    0        5003          0         41         46  POST /api/events/11/actions/reserve HTTP/1.1
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
  118  14.794  0.125373  0.058796   0.037   0.118   0.209   0.233   0.280   0.282  118    0    0    0     6251219      52971      52976      52998  GET /api/events/10 HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
    6   4.058  0.676333  0.448627   0.398   0.488   1.663   1.663   1.663   1.663    6    0    0    0     2991463         67     498577     997608  GET /admin/api/reports/events/10/sales HTTP/1.1
    9   2.869  0.318778  0.538477   0.004   0.033   1.738   1.738   1.738   1.738    8    0    1    0        3056          0        339        989  GET /admin/api/reports/events/11/sales HTTP/1.1
    1   2.810  2.810000  0.000000   2.810   2.810   2.810   2.810   2.810   2.810    1    0    0    0           0          0          0          0  DELETE /api/events/11/sheets/C/194/reservation HTTP/1.1
    1   2.796  2.796000  0.000000   2.796   2.796   2.796   2.796   2.796   2.796    1    0    0    0        2573       2573       2573       2573  GET /api/users/2272 HTTP/1.1
    1   2.756  2.756000  0.000000   2.756   2.756   2.756   2.756   2.756   2.756    1    0    0    0        2443       2443       2443       2443  GET /api/users/2226 HTTP/1.1
    1   2.681  2.681000  0.000000   2.681   2.681   2.681   2.681   2.681   2.681    1    0    0    0        2510       2510       2510       2510  GET /api/users/3085 HTTP/1.1
    1   2.576  2.576000  0.000000   2.576   2.576   2.576   2.576   2.576   2.576    1    0    0    0        2479       2479       2479       2479  GET /api/users/70 HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/10/sheets/B/58/reservation HTTP/1.1
    1   2.515  2.515000  0.000000   2.515   2.515   2.515   2.515   2.515   2.515    1    0    0    0        2404       2404       2404       2404  GET /api/users/53 HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
    4   2.429  0.607250  0.883425   0.028   0.190   2.134   2.134   2.134   2.134    4    0    0    0         268         67         67         67  GET /admin/api/reports/events/20/sales HTTP/1.1
    6   2.411  0.401833  0.811961   0.010   0.048   2.217   2.217   2.217   2.217    6    0    0    0         402         67         67         67  GET /admin/api/reports/events/19/sales HTTP/1.1
    1   2.396  2.396000  0.000000   2.396   2.396   2.396   2.396   2.396   2.396    1    0    0    0        2494       2494       2494       2494  GET /api/users/836 HTTP/1.1
    1   2.345  2.345000  0.000000   2.345   2.345   2.345   2.345   2.345   2.345    1    0    0    0        2478       2478       2478       2478  GET /api/users/4740 HTTP/1.1

Top 20 Sort By Mean
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
    1   2.810  2.810000  0.000000   2.810   2.810   2.810   2.810   2.810   2.810    1    0    0    0           0          0          0          0  DELETE /api/events/11/sheets/C/194/reservation HTTP/1.1
    1   2.796  2.796000  0.000000   2.796   2.796   2.796   2.796   2.796   2.796    1    0    0    0        2573       2573       2573       2573  GET /api/users/2272 HTTP/1.1
    1   2.756  2.756000  0.000000   2.756   2.756   2.756   2.756   2.756   2.756    1    0    0    0        2443       2443       2443       2443  GET /api/users/2226 HTTP/1.1
    1   2.681  2.681000  0.000000   2.681   2.681   2.681   2.681   2.681   2.681    1    0    0    0        2510       2510       2510       2510  GET /api/users/3085 HTTP/1.1
    1   2.576  2.576000  0.000000   2.576   2.576   2.576   2.576   2.576   2.576    1    0    0    0        2479       2479       2479       2479  GET /api/users/70 HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/10/sheets/B/58/reservation HTTP/1.1
    1   2.515  2.515000  0.000000   2.515   2.515   2.515   2.515   2.515   2.515    1    0    0    0        2404       2404       2404       2404  GET /api/users/53 HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
    1   2.396  2.396000  0.000000   2.396   2.396   2.396   2.396   2.396   2.396    1    0    0    0        2494       2494       2494       2494  GET /api/users/836 HTTP/1.1
    1   2.345  2.345000  0.000000   2.345   2.345   2.345   2.345   2.345   2.345    1    0    0    0        2478       2478       2478       2478  GET /api/users/4740 HTTP/1.1
    1   2.208  2.208000  0.000000   2.208   2.208   2.208   2.208   2.208   2.208    1    0    0    0        2456       2456       2456       2456  GET /api/users/1580 HTTP/1.1
    1   2.195  2.195000  0.000000   2.195   2.195   2.195   2.195   2.195   2.195    1    0    0    0        2527       2527       2527       2527  GET /api/users/148 HTTP/1.1
    1   2.194  2.194000  0.000000   2.194   2.194   2.194   2.194   2.194   2.194    1    0    0    0        2496       2496       2496       2496  GET /api/users/3916 HTTP/1.1
    1   2.006  2.006000  0.000000   2.006   2.006   2.006   2.006   2.006   2.006    1    0    0    0        2388       2388       2388       2388  GET /api/users/4824 HTTP/1.1
    1   1.795  1.795000  0.000000   1.795   1.795   1.795   1.795   1.795   1.795    1    0    0    0        2522       2522       2522       2522  GET /api/users/3496 HTTP/1.1
    1   1.615  1.615000  0.000000   1.615   1.615   1.615   1.615   1.615   1.615    1    0    0    0        2480       2480       2480       2480  GET /api/users/3738 HTTP/1.1
    1   1.198  1.198000  0.000000   1.198   1.198   1.198   1.198   1.198   1.198    1    0    0    0        2469       2469       2469       2469  GET /api/users/1468 HTTP/1.1
    1   0.688  0.688000  0.000000   0.688   0.688   0.688   0.688   0.688   0.688    1    0    0    0        2518       2518       2518       2518  GET /api/users/4035 HTTP/1.1
    6   4.058  0.676333  0.448627   0.398   0.488   1.663   1.663   1.663   1.663    6    0    0    0     2991463         67     498577     997608  GET /admin/api/reports/events/10/sales HTTP/1.1

Top 20 Sort By Standard Deviation
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
    4   2.429  0.607250  0.883425   0.028   0.190   2.134   2.134   2.134   2.134    4    0    0    0         268         67         67         67  GET /admin/api/reports/events/20/sales HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
  120  48.435  0.403625  0.848648   0.000   0.086   2.351   2.840   3.001   3.004  105    0   15    0        5003          0         41         46  POST /api/events/11/actions/reserve HTTP/1.1
    6   2.411  0.401833  0.811961   0.010   0.048   2.217   2.217   2.217   2.217    6    0    0    0         402         67         67         67  GET /admin/api/reports/events/19/sales HTTP/1.1
    9   2.869  0.318778  0.538477   0.004   0.033   1.738   1.738   1.738   1.738    8    0    1    0        3056          0        339        989  GET /admin/api/reports/events/11/sales HTTP/1.1
    6   4.058  0.676333  0.448627   0.398   0.488   1.663   1.663   1.663   1.663    6    0    0    0     2991463         67     498577     997608  GET /admin/api/reports/events/10/sales HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
    3   0.421  0.140333  0.106684   0.049   0.082   0.290   0.290   0.290   0.290    3    0    0    0         137         45         45         46  POST /api/events/10/actions/reserve HTTP/1.1
    3   0.288  0.096000  0.092445   0.019   0.043   0.226   0.226   0.226   0.226    1    0    2    0       12024         21       4008      11971  POST /admin/api/events/21/actions/edit HTTP/1.1
  118  14.794  0.125373  0.058796   0.037   0.118   0.209   0.233   0.280   0.282  118    0    0    0     6251219      52971      52976      52998  GET /api/events/10 HTTP/1.1
   32   1.852  0.057875  0.055826   0.002   0.043   0.109   0.168   0.258   0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
    3   0.161  0.053667  0.043484   0.010   0.038   0.113   0.113   0.113   0.113    1    0    2    0       11986         21       3995      11944  GET /api/events/21 HTTP/1.1
    2   0.135  0.067500  0.037500   0.030   0.105   0.105   0.105   0.105   0.105    2    0    0    0           0          0          0          0  DELETE /api/events/11/sheets/C/56/reservation HTTP/1.1
   48   1.525  0.031771  0.037419   0.000   0.015   0.085   0.123   0.147   0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
    4   0.155  0.038750  0.029431   0.013   0.038   0.087   0.087   0.087   0.087    2    0    2    0       23988         21       5997      11971  GET /admin/api/events/21 HTTP/1.1
    4   0.128  0.032000  0.027632   0.002   0.036   0.075   0.075   0.075   0.075    2    0    2    0       23979         21       5994      11970  GET /admin/api/events/20 HTTP/1.1
    8   0.146  0.018250  0.025922   0.000   0.005   0.070   0.070   0.070   0.070    4    0    4    0       47961         32       5995      11963  POST /admin/api/events HTTP/1.1
    3   0.108  0.036000  0.024658   0.004   0.040   0.064   0.064   0.064   0.064    1    0    2    0       11986         21       3995      11944  GET /api/events/22 HTTP/1.1

Top 20 Sort By Maximum(100 Percentile)
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
  120  48.435  0.403625  0.848648   0.000   0.086   2.351   2.840   3.001   3.004  105    0   15    0        5003          0         41         46  POST /api/events/11/actions/reserve HTTP/1.1
    1   2.810  2.810000  0.000000   2.810   2.810   2.810   2.810   2.810   2.810    1    0    0    0           0          0          0          0  DELETE /api/events/11/sheets/C/194/reservation HTTP/1.1
    1   2.796  2.796000  0.000000   2.796   2.796   2.796   2.796   2.796   2.796    1    0    0    0        2573       2573       2573       2573  GET /api/users/2272 HTTP/1.1
    1   2.756  2.756000  0.000000   2.756   2.756   2.756   2.756   2.756   2.756    1    0    0    0        2443       2443       2443       2443  GET /api/users/2226 HTTP/1.1
    1   2.681  2.681000  0.000000   2.681   2.681   2.681   2.681   2.681   2.681    1    0    0    0        2510       2510       2510       2510  GET /api/users/3085 HTTP/1.1
    1   2.576  2.576000  0.000000   2.576   2.576   2.576   2.576   2.576   2.576    1    0    0    0        2479       2479       2479       2479  GET /api/users/70 HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/10/sheets/B/58/reservation HTTP/1.1
    1   2.515  2.515000  0.000000   2.515   2.515   2.515   2.515   2.515   2.515    1    0    0    0        2404       2404       2404       2404  GET /api/users/53 HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
    1   2.396  2.396000  0.000000   2.396   2.396   2.396   2.396   2.396   2.396    1    0    0    0        2494       2494       2494       2494  GET /api/users/836 HTTP/1.1
    1   2.345  2.345000  0.000000   2.345   2.345   2.345   2.345   2.345   2.345    1    0    0    0        2478       2478       2478       2478  GET /api/users/4740 HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
    6   2.411  0.401833  0.811961   0.010   0.048   2.217   2.217   2.217   2.217    6    0    0    0         402         67         67         67  GET /admin/api/reports/events/19/sales HTTP/1.1
    1   2.208  2.208000  0.000000   2.208   2.208   2.208   2.208   2.208   2.208    1    0    0    0        2456       2456       2456       2456  GET /api/users/1580 HTTP/1.1
    1   2.195  2.195000  0.000000   2.195   2.195   2.195   2.195   2.195   2.195    1    0    0    0        2527       2527       2527       2527  GET /api/users/148 HTTP/1.1
    1   2.194  2.194000  0.000000   2.194   2.194   2.194   2.194   2.194   2.194    1    0    0    0        2496       2496       2496       2496  GET /api/users/3916 HTTP/1.1
    4   2.429  0.607250  0.883425   0.028   0.190   2.134   2.134   2.134   2.134    4    0    0    0         268         67         67         67  GET /admin/api/reports/events/20/sales HTTP/1.1
    1   2.006  2.006000  0.000000   2.006   2.006   2.006   2.006   2.006   2.006    1    0    0    0        2388       2388       2388       2388  GET /api/users/4824 HTTP/1.1
    1   1.795  1.795000  0.000000   1.795   1.795   1.795   1.795   1.795   1.795    1    0    0    0        2522       2522       2522       2522  GET /api/users/3496 HTTP/1.1

TOP 37 Slow Requests
 1  12.710  GET /admin/api/reports/sales HTTP/1.1
 2   7.935  GET /admin/api/reports/sales HTTP/1.1
 3   7.668  GET /admin/api/reports/sales HTTP/1.1
 4   3.004  POST /api/events/11/actions/reserve HTTP/1.1
 5   3.001  POST /api/events/11/actions/reserve HTTP/1.1
 6   2.991  POST /api/events/11/actions/reserve HTTP/1.1
 7   2.948  POST /api/events/11/actions/reserve HTTP/1.1
 8   2.926  POST /api/events/11/actions/reserve HTTP/1.1
 9   2.840  POST /api/events/11/actions/reserve HTTP/1.1
10   2.810  POST /api/events/11/actions/reserve HTTP/1.1
11   2.810  DELETE /api/events/11/sheets/C/194/reservation HTTP/1.1
12   2.796  GET /api/users/2272 HTTP/1.1
13   2.774  POST /api/events/11/actions/reserve HTTP/1.1
14   2.756  GET /api/users/2226 HTTP/1.1
15   2.700  POST /api/events/11/actions/reserve HTTP/1.1
16   2.682  POST /api/events/11/actions/reserve HTTP/1.1
17   2.681  GET /api/users/3085 HTTP/1.1
18   2.576  GET /api/users/70 HTTP/1.1
19   2.566  DELETE /api/events/10/sheets/B/58/reservation HTTP/1.1
20   2.515  GET /api/users/53 HTTP/1.1
21   2.465  POST /api/events/11/actions/reserve HTTP/1.1
22   2.436  GET /initialize HTTP/1.1
23   2.396  GET /api/users/836 HTTP/1.1
24   2.351  POST /api/events/11/actions/reserve HTTP/1.1
25   2.345  GET /api/users/4740 HTTP/1.1
26   2.243  GET /admin/ HTTP/1.1
27   2.234  POST /api/events/11/actions/reserve HTTP/1.1
28   2.217  GET /admin/api/reports/events/19/sales HTTP/1.1
29   2.208  GET /api/users/1580 HTTP/1.1
30   2.195  GET /api/users/148 HTTP/1.1
31   2.194  GET /api/users/3916 HTTP/1.1
32   2.184  POST /api/events/11/actions/reserve HTTP/1.1
33   2.184  GET /admin/ HTTP/1.1
34   2.134  GET /admin/api/reports/events/20/sales HTTP/1.1
35   2.064  GET /admin/ HTTP/1.1
36   2.022  GET /admin/ HTTP/1.1
37   2.006  GET /api/users/4824 HTTP/1.1
```

</details>

**After (with `normalize_numerical_urlvars = true` ):**

```
Top 20 Sort By Total
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  127  48.878  0.384866  0.828888   0.000   0.085   2.234   2.810   3.001   3.004  108    0   19    0        5240          0         41         46  POST /api/events/<num>/actions/reserve HTTP/1.1
   17  32.672  1.921882  0.789541   0.171   2.195   2.756   2.796   2.796   2.796   16    0    1    0       39670          0       2333       2573  GET /api/users/<num> HTTP/1.1
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
  130  15.192  0.116862  0.062808   0.000   0.107   0.208   0.228   0.280   0.282  122    0    8    0     6299168         21      48455      52998  GET /api/events/<num> HTTP/1.1
   25  11.767  0.470680  0.677027   0.004   0.077   1.738   2.134   2.217   2.217   24    0    1    0     2995189          0     119807     997608  GET /admin/api/reports/events/<num>/sales HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
   49   6.511  0.132878  0.397356   0.000   0.050   0.173   0.241   2.810   2.810   41    0    8    0         204          0          4         26  DELETE /api/events/<num>/sheets/C/<num>/reservation HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/<num>/sheets/B/<num>/reservation HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
   32   1.852  0.057875  0.055826   0.002   0.043   0.109   0.168   0.258   0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
   48   1.525  0.031771  0.037419   0.000   0.015   0.085   0.123   0.147   0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
   16   0.478  0.029875  0.027926   0.001   0.017   0.075   0.087   0.087   0.087    8    0    8    0       95941         21       5996      11977  GET /admin/api/events/<num> HTTP/1.1
   12   0.353  0.029417  0.060684   0.001   0.008   0.043   0.226   0.226   0.226    4    0    8    0       48101         21       4008      11977  POST /admin/api/events/<num>/actions/edit HTTP/1.1
    4   0.221  0.055250  0.057950   0.004   0.063   0.147   0.147   0.147   0.147    0    0    4    0         100         25         25         25  DELETE /api/events/<num>/sheets/S/<num>/reservation HTTP/1.1
    8   0.146  0.018250  0.025922   0.000   0.005   0.070   0.070   0.070   0.070    4    0    4    0       47961         32       5995      11963  POST /admin/api/events HTTP/1.1
  143   0.129  0.000902  0.002859   0.000   0.000   0.001   0.007   0.013   0.021  143    0    0    0    20152990     140930     140930     140930  GET /css/bootstrap.min.css HTTP/1.1
    8   0.088  0.011000  0.018276   0.001   0.002   0.056   0.056   0.056   0.056    4    0    4    0         128          0         16         32  POST /admin/api/actions/logout HTTP/1.1
    4   0.044  0.011000  0.010977   0.004   0.005   0.030   0.030   0.030   0.030    0    0    4    0          96         24         24         24  DELETE /api/events/<num>/sheets/D/<num>/reservation HTTP/1.1
```


<details>

<summary>full output</summary>

```
$ go build . && less ./access.log | ./kataribe 
Top 20 Sort By Count
Count   Total      Mean    Stddev    Min  P50.0  P90.0  P95.0  P99.0    Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  291  10.790  0.037079  0.044029  0.001  0.021  0.092  0.138  0.188  0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0       97812        684        684        684  GET /css/admin.css HTTP/1.1
  143   0.033  0.000231  0.001408  0.000  0.000  0.000  0.000  0.010  0.011  143    0    0    0    12362636      86452      86452      86452  GET /js/vue.min.js HTTP/1.1
  143   0.008  0.000056  0.000308  0.000  0.000  0.000  0.000  0.001  0.003  143    0    0    0    10107526      70682      70682      70682  GET /js/bootstrap.bundle.min.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0     1049191       7337       7337       7337  GET /js/fetch.min.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0     1208922       8454       8454       8454  GET /js/admin.js HTTP/1.1
  143   0.129  0.000902  0.002859  0.000  0.000  0.001  0.007  0.013  0.021  143    0    0    0    20152990     140930     140930     140930  GET /css/bootstrap.min.css HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0      156156       1092       1092       1092  GET /favicon.ico HTTP/1.1
  143   0.018  0.000126  0.000938  0.000  0.000  0.000  0.001  0.001  0.011  143    0    0    0     9998131      69917      69917      69917  GET /js/jquery-3.3.1.slim.min.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0     1459172      10204      10204      10204  GET /js/app.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0      296582       2074       2074       2074  GET /js/bootstrap-waitingfor.min.js HTTP/1.1
  143   0.000  0.000000  0.000000  0.000  0.000  0.000  0.000  0.000  0.000  143    0    0    0      101101        707        707        707  GET /css/layout.css HTTP/1.1
  130  15.192  0.116862  0.062808  0.000  0.107  0.208  0.228  0.280  0.282  122    0    8    0     6299168         21      48455      52998  GET /api/events/<num> HTTP/1.1
  127  48.878  0.384866  0.828888  0.000  0.085  2.234  2.810  3.001  3.004  108    0   19    0        5240          0         41         46  POST /api/events/<num>/actions/reserve HTTP/1.1
  118  28.418  0.240831  0.118731  0.033  0.245  0.411  0.438  0.525  0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
   49   6.511  0.132878  0.397356  0.000  0.050  0.173  0.241  2.810  2.810   41    0    8    0         204          0          4         26  DELETE /api/events/<num>/sheets/C/<num>/reservation HTTP/1.1
   48   1.525  0.031771  0.037419  0.000  0.015  0.085  0.123  0.147  0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
   32   1.852  0.057875  0.055826  0.002  0.043  0.109  0.168  0.258  0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
   31  16.499  0.532226  0.869186  0.001  0.011  2.022  2.184  2.243  2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
   25  11.767  0.470680  0.677027  0.004  0.077  1.738  2.134  2.217  2.217   24    0    1    0     2995189          0     119807     997608  GET /admin/api/reports/events/<num>/sales HTTP/1.1

Top 20 Sort By Total
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  127  48.878  0.384866  0.828888   0.000   0.085   2.234   2.810   3.001   3.004  108    0   19    0        5240          0         41         46  POST /api/events/<num>/actions/reserve HTTP/1.1
   17  32.672  1.921882  0.789541   0.171   2.195   2.756   2.796   2.796   2.796   16    0    1    0       39670          0       2333       2573  GET /api/users/<num> HTTP/1.1
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
  130  15.192  0.116862  0.062808   0.000   0.107   0.208   0.228   0.280   0.282  122    0    8    0     6299168         21      48455      52998  GET /api/events/<num> HTTP/1.1
   25  11.767  0.470680  0.677027   0.004   0.077   1.738   2.134   2.217   2.217   24    0    1    0     2995189          0     119807     997608  GET /admin/api/reports/events/<num>/sales HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
   49   6.511  0.132878  0.397356   0.000   0.050   0.173   0.241   2.810   2.810   41    0    8    0         204          0          4         26  DELETE /api/events/<num>/sheets/C/<num>/reservation HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/<num>/sheets/B/<num>/reservation HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
   32   1.852  0.057875  0.055826   0.002   0.043   0.109   0.168   0.258   0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
   48   1.525  0.031771  0.037419   0.000   0.015   0.085   0.123   0.147   0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
   16   0.478  0.029875  0.027926   0.001   0.017   0.075   0.087   0.087   0.087    8    0    8    0       95941         21       5996      11977  GET /admin/api/events/<num> HTTP/1.1
   12   0.353  0.029417  0.060684   0.001   0.008   0.043   0.226   0.226   0.226    4    0    8    0       48101         21       4008      11977  POST /admin/api/events/<num>/actions/edit HTTP/1.1
    4   0.221  0.055250  0.057950   0.004   0.063   0.147   0.147   0.147   0.147    0    0    4    0         100         25         25         25  DELETE /api/events/<num>/sheets/S/<num>/reservation HTTP/1.1
    8   0.146  0.018250  0.025922   0.000   0.005   0.070   0.070   0.070   0.070    4    0    4    0       47961         32       5995      11963  POST /admin/api/events HTTP/1.1
  143   0.129  0.000902  0.002859   0.000   0.000   0.001   0.007   0.013   0.021  143    0    0    0    20152990     140930     140930     140930  GET /css/bootstrap.min.css HTTP/1.1
    8   0.088  0.011000  0.018276   0.001   0.002   0.056   0.056   0.056   0.056    4    0    4    0         128          0         16         32  POST /admin/api/actions/logout HTTP/1.1
    4   0.044  0.011000  0.010977   0.004   0.005   0.030   0.030   0.030   0.030    0    0    4    0          96         24         24         24  DELETE /api/events/<num>/sheets/D/<num>/reservation HTTP/1.1

Top 20 Sort By Mean
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/<num>/sheets/B/<num>/reservation HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
   17  32.672  1.921882  0.789541   0.171   2.195   2.756   2.796   2.796   2.796   16    0    1    0       39670          0       2333       2573  GET /api/users/<num> HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
   25  11.767  0.470680  0.677027   0.004   0.077   1.738   2.134   2.217   2.217   24    0    1    0     2995189          0     119807     997608  GET /admin/api/reports/events/<num>/sales HTTP/1.1
  127  48.878  0.384866  0.828888   0.000   0.085   2.234   2.810   3.001   3.004  108    0   19    0        5240          0         41         46  POST /api/events/<num>/actions/reserve HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
   49   6.511  0.132878  0.397356   0.000   0.050   0.173   0.241   2.810   2.810   41    0    8    0         204          0          4         26  DELETE /api/events/<num>/sheets/C/<num>/reservation HTTP/1.1
  130  15.192  0.116862  0.062808   0.000   0.107   0.208   0.228   0.280   0.282  122    0    8    0     6299168         21      48455      52998  GET /api/events/<num> HTTP/1.1
   32   1.852  0.057875  0.055826   0.002   0.043   0.109   0.168   0.258   0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
    4   0.221  0.055250  0.057950   0.004   0.063   0.147   0.147   0.147   0.147    0    0    4    0         100         25         25         25  DELETE /api/events/<num>/sheets/S/<num>/reservation HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
   48   1.525  0.031771  0.037419   0.000   0.015   0.085   0.123   0.147   0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
   16   0.478  0.029875  0.027926   0.001   0.017   0.075   0.087   0.087   0.087    8    0    8    0       95941         21       5996      11977  GET /admin/api/events/<num> HTTP/1.1
   12   0.353  0.029417  0.060684   0.001   0.008   0.043   0.226   0.226   0.226    4    0    8    0       48101         21       4008      11977  POST /admin/api/events/<num>/actions/edit HTTP/1.1
    8   0.146  0.018250  0.025922   0.000   0.005   0.070   0.070   0.070   0.070    4    0    4    0       47961         32       5995      11963  POST /admin/api/events HTTP/1.1
    8   0.088  0.011000  0.018276   0.001   0.002   0.056   0.056   0.056   0.056    4    0    4    0         128          0         16         32  POST /admin/api/actions/logout HTTP/1.1
    4   0.044  0.011000  0.010977   0.004   0.005   0.030   0.030   0.030   0.030    0    0    4    0          96         24         24         24  DELETE /api/events/<num>/sheets/D/<num>/reservation HTTP/1.1
    8   0.021  0.002625  0.004328   0.000   0.001   0.014   0.014   0.014   0.014    4    0    4    0         104          0         13         26  POST /api/actions/logout HTTP/1.1

Top 20 Sort By Standard Deviation
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
  127  48.878  0.384866  0.828888   0.000   0.085   2.234   2.810   3.001   3.004  108    0   19    0        5240          0         41         46  POST /api/events/<num>/actions/reserve HTTP/1.1
   17  32.672  1.921882  0.789541   0.171   2.195   2.756   2.796   2.796   2.796   16    0    1    0       39670          0       2333       2573  GET /api/users/<num> HTTP/1.1
   25  11.767  0.470680  0.677027   0.004   0.077   1.738   2.134   2.217   2.217   24    0    1    0     2995189          0     119807     997608  GET /admin/api/reports/events/<num>/sales HTTP/1.1
   49   6.511  0.132878  0.397356   0.000   0.050   0.173   0.241   2.810   2.810   41    0    8    0         204          0          4         26  DELETE /api/events/<num>/sheets/C/<num>/reservation HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
  130  15.192  0.116862  0.062808   0.000   0.107   0.208   0.228   0.280   0.282  122    0    8    0     6299168         21      48455      52998  GET /api/events/<num> HTTP/1.1
   12   0.353  0.029417  0.060684   0.001   0.008   0.043   0.226   0.226   0.226    4    0    8    0       48101         21       4008      11977  POST /admin/api/events/<num>/actions/edit HTTP/1.1
    4   0.221  0.055250  0.057950   0.004   0.063   0.147   0.147   0.147   0.147    0    0    4    0         100         25         25         25  DELETE /api/events/<num>/sheets/S/<num>/reservation HTTP/1.1
   32   1.852  0.057875  0.055826   0.002   0.043   0.109   0.168   0.258   0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
   48   1.525  0.031771  0.037419   0.000   0.015   0.085   0.123   0.147   0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
   16   0.478  0.029875  0.027926   0.001   0.017   0.075   0.087   0.087   0.087    8    0    8    0       95941         21       5996      11977  GET /admin/api/events/<num> HTTP/1.1
    8   0.146  0.018250  0.025922   0.000   0.005   0.070   0.070   0.070   0.070    4    0    4    0       47961         32       5995      11963  POST /admin/api/events HTTP/1.1
    8   0.088  0.011000  0.018276   0.001   0.002   0.056   0.056   0.056   0.056    4    0    4    0         128          0         16         32  POST /admin/api/actions/logout HTTP/1.1
    4   0.044  0.011000  0.010977   0.004   0.005   0.030   0.030   0.030   0.030    0    0    4    0          96         24         24         24  DELETE /api/events/<num>/sheets/D/<num>/reservation HTTP/1.1
    8   0.021  0.002625  0.004328   0.000   0.001   0.014   0.014   0.014   0.014    4    0    4    0         104          0         13         26  POST /api/actions/logout HTTP/1.1
  143   0.129  0.000902  0.002859   0.000   0.000   0.001   0.007   0.013   0.021  143    0    0    0    20152990     140930     140930     140930  GET /css/bootstrap.min.css HTTP/1.1
  143   0.033  0.000231  0.001408   0.000   0.000   0.000   0.000   0.010   0.011  143    0    0    0    12362636      86452      86452      86452  GET /js/vue.min.js HTTP/1.1

Top 20 Sort By Maximum(100 Percentile)
Count   Total      Mean    Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max  2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
    4  29.548  7.387000  4.079237   1.235   7.935  12.710  12.710  12.710  12.710    3    0    1    0    44957260          0   11239315   14986569  GET /admin/api/reports/sales HTTP/1.1
  127  48.878  0.384866  0.828888   0.000   0.085   2.234   2.810   3.001   3.004  108    0   19    0        5240          0         41         46  POST /api/events/<num>/actions/reserve HTTP/1.1
   49   6.511  0.132878  0.397356   0.000   0.050   0.173   0.241   2.810   2.810   41    0    8    0         204          0          4         26  DELETE /api/events/<num>/sheets/C/<num>/reservation HTTP/1.1
   17  32.672  1.921882  0.789541   0.171   2.195   2.756   2.796   2.796   2.796   16    0    1    0       39670          0       2333       2573  GET /api/users/<num> HTTP/1.1
    1   2.566  2.566000  0.000000   2.566   2.566   2.566   2.566   2.566   2.566    1    0    0    0           0          0          0          0  DELETE /api/events/<num>/sheets/B/<num>/reservation HTTP/1.1
    1   2.436  2.436000  0.000000   2.436   2.436   2.436   2.436   2.436   2.436    1    0    0    0           0          0          0          0  GET /initialize HTTP/1.1
   31  16.499  0.532226  0.869186   0.001   0.011   2.022   2.184   2.243   2.243   31    0    0    0      440308      11351      14203      21773  GET /admin/ HTTP/1.1
   25  11.767  0.470680  0.677027   0.004   0.077   1.738   2.134   2.217   2.217   24    0    1    0     2995189          0     119807     997608  GET /admin/api/reports/events/<num>/sales HTTP/1.1
  118  28.418  0.240831  0.118731   0.033   0.245   0.411   0.438   0.525   0.560  118    0    0    0     1803480      14314      15283      16087  GET / HTTP/1.1
  291  10.790  0.037079  0.044029   0.001   0.021   0.092   0.138   0.188   0.289  283    0    8    0       10734         31         36         42  POST /api/actions/login HTTP/1.1
  130  15.192  0.116862  0.062808   0.000   0.107   0.208   0.228   0.280   0.282  122    0    8    0     6299168         21      48455      52998  GET /api/events/<num> HTTP/1.1
   32   1.852  0.057875  0.055826   0.002   0.043   0.109   0.168   0.258   0.258   28    0    4    0        1116         22         34         41  POST /api/users HTTP/1.1
   12   0.353  0.029417  0.060684   0.001   0.008   0.043   0.226   0.226   0.226    4    0    8    0       48101         21       4008      11977  POST /admin/api/events/<num>/actions/edit HTTP/1.1
   48   1.525  0.031771  0.037419   0.000   0.015   0.085   0.123   0.147   0.147   36    0   12    0        1708         27         35         42  POST /admin/api/actions/login HTTP/1.1
    4   0.221  0.055250  0.057950   0.004   0.063   0.147   0.147   0.147   0.147    0    0    4    0         100         25         25         25  DELETE /api/events/<num>/sheets/S/<num>/reservation HTTP/1.1
   16   0.478  0.029875  0.027926   0.001   0.017   0.075   0.087   0.087   0.087    8    0    8    0       95941         21       5996      11977  GET /admin/api/events/<num> HTTP/1.1
    8   0.146  0.018250  0.025922   0.000   0.005   0.070   0.070   0.070   0.070    4    0    4    0       47961         32       5995      11963  POST /admin/api/events HTTP/1.1
    8   0.088  0.011000  0.018276   0.001   0.002   0.056   0.056   0.056   0.056    4    0    4    0         128          0         16         32  POST /admin/api/actions/logout HTTP/1.1
    4   0.044  0.011000  0.010977   0.004   0.005   0.030   0.030   0.030   0.030    0    0    4    0          96         24         24         24  DELETE /api/events/<num>/sheets/D/<num>/reservation HTTP/1.1
  143   0.129  0.000902  0.002859   0.000   0.000   0.001   0.007   0.013   0.021  143    0    0    0    20152990     140930     140930     140930  GET /css/bootstrap.min.css HTTP/1.1

TOP 37 Slow Requests
 1  12.710  GET /admin/api/reports/sales HTTP/1.1
 2   7.935  GET /admin/api/reports/sales HTTP/1.1
 3   7.668  GET /admin/api/reports/sales HTTP/1.1
 4   3.004  POST /api/events/11/actions/reserve HTTP/1.1
 5   3.001  POST /api/events/11/actions/reserve HTTP/1.1
 6   2.991  POST /api/events/11/actions/reserve HTTP/1.1
 7   2.948  POST /api/events/11/actions/reserve HTTP/1.1
 8   2.926  POST /api/events/11/actions/reserve HTTP/1.1
 9   2.840  POST /api/events/11/actions/reserve HTTP/1.1
10   2.810  POST /api/events/11/actions/reserve HTTP/1.1
11   2.810  DELETE /api/events/11/sheets/C/194/reservation HTTP/1.1
12   2.796  GET /api/users/2272 HTTP/1.1
13   2.774  POST /api/events/11/actions/reserve HTTP/1.1
14   2.756  GET /api/users/2226 HTTP/1.1
15   2.700  POST /api/events/11/actions/reserve HTTP/1.1
16   2.682  POST /api/events/11/actions/reserve HTTP/1.1
17   2.681  GET /api/users/3085 HTTP/1.1
18   2.576  GET /api/users/70 HTTP/1.1
19   2.566  DELETE /api/events/10/sheets/B/58/reservation HTTP/1.1
20   2.515  GET /api/users/53 HTTP/1.1
21   2.465  POST /api/events/11/actions/reserve HTTP/1.1
22   2.436  GET /initialize HTTP/1.1
23   2.396  GET /api/users/836 HTTP/1.1
24   2.351  POST /api/events/11/actions/reserve HTTP/1.1
25   2.345  GET /api/users/4740 HTTP/1.1
26   2.243  GET /admin/ HTTP/1.1
27   2.234  POST /api/events/11/actions/reserve HTTP/1.1
28   2.217  GET /admin/api/reports/events/19/sales HTTP/1.1
29   2.208  GET /api/users/1580 HTTP/1.1
30   2.195  GET /api/users/148 HTTP/1.1
31   2.194  GET /api/users/3916 HTTP/1.1
32   2.184  POST /api/events/11/actions/reserve HTTP/1.1
33   2.184  GET /admin/ HTTP/1.1
34   2.134  GET /admin/api/reports/events/20/sales HTTP/1.1
35   2.064  GET /admin/ HTTP/1.1
36   2.022  GET /admin/ HTTP/1.1
37   2.006  GET /api/users/4824 HTTP/1.1
```

</details>