### PR TITLE
Support for json format logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,35 @@ logger = Logger.new("/tmp/app.log")
 use Rack::CommonLogger, logger
 ```
 
+### JSON
+
+Please follow the following json format.
+
+```json
+{
+  "request":"POST /example HTTP/1.1",
+  "status":200,
+  "body_bytes":0,
+  "request_time":0.224
+}
+```
+
+Here's an example of how to configure nginx.
+
+```
+log_format with_time escape=json '{"remote_addr":"$remote_addr",'
+  '"remote_user":"$remote_user",'
+  '"time":"$time_local",'
+  '"request":"$request",'
+  '"status":$status,'
+  '"body_bytes":$body_bytes_sent,'
+  '"http_referer":"$http_referer",'
+  '"http_user_agent":"$http_user_agent",'
+  '"request_time":$request_time}';
+
+access_log /var/log/nginx/access.log with_time;
+```
+
 ## Usage
 
 Install via go command or download [release file](https://github.com/matsuu/kataribe/releases)
@@ -167,4 +196,3 @@ Apache-2.0
 ## Author
 
 [matsuu](https://github.com/matsuu)
-

--- a/toml.go
+++ b/toml.go
@@ -43,6 +43,10 @@ status_index = 6
 bytes_index = 7
 duration_index = 10
 
+# The default is ltsv.
+# If you choose json, please comment in.
+# parser = "json"
+
 # Rack example: use Rack::CommonLogger, Logger.new("/tmp/app.log")
 #log_format = '^([^ ]+) ([^ ]+) ([^ ]+) \[([^\]]+)\] "((?:\\"|[^"])*)" (\d+) (\d+|-) ([0-9.]+)$'
 #request_index = 5


### PR DESCRIPTION
I'm always making use of this tool. Thanks.

I think the json format would be easier to handle for using kataribe and other tools together.
That's why I put out a PR supporting logs in json format.